### PR TITLE
WIP: Initial metrics collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.tgz

--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+var Collector = require('./lib/collector');
+var Reporter = require('./lib/reporter');
+
+module.exports = exports = simple;
+exports.Reporter = Reporter;
+exports.Collector = Collector;
+
+function simple(opts) {
+  var reporter = new Reporter(opts);
+  var collector = new Collector(opts);
+  var adapter = collector.collect.bind(collector);
+  adapter.stop = collector.stop.bind(collector);
+  collector.on('metrics', reporter.prepare.bind(reporter));
+  return adapter;
+}

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -1,0 +1,53 @@
+var debug = require('debug')('strong-agent-ca:collector');
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('util').inherits;
+
+module.exports = exports = Collector;
+
+function Collector(opts) {
+  if (!(this instanceof Collector))
+    return new Collector(opts);
+
+  EventEmitter.call(this);
+
+  this.store = {};
+  this.interval = opts.interval || 15000;
+
+  this.on('newListener', this.start.bind(this));
+}
+
+inherits(Collector, EventEmitter);
+
+Collector.prototype.start = start;
+Collector.prototype.stop = stop;
+Collector.prototype.collect = collect;
+Collector.prototype.dump = dump;
+
+function start() {
+  if (this.timer) {
+    debug('already started');
+    return;
+  }
+  debug('starting');
+
+  // ensure interval is an integer
+  this.timer = setInterval(this.dump.bind(this), this.interval|0);
+  // ensure we do not keep the event loop alive if everything else finishes
+  this.timer.unref();
+}
+
+function stop() {
+  clearInterval(this.timer);
+  this.timer = null;
+}
+
+function collect(name, value) {
+  // TODO: properly accumulate state
+  debug('collect(%j,%j)', name, value);
+  this.store[name] = value;
+}
+
+function dump() {
+  var copy = JSON.parse(JSON.stringify(this.store));
+  this.emit('metrics', copy);
+}

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2014, StrongLoop
+
+// XXX: lodash is currently only used for memoize
+var lodash = require('lodash');
+var nameOf = lodash.memoize(translateName);
+var typeOf = lodash.memoize(translateType);
+
+module.exports = exports = makeCaMetric;
+exports.getValue = valueOf;
+exports.getName = nameOf;
+exports.getType = typeOf;
+
+// Turn prefix, name, value into a metric entry object
+function makeCaMetric(prefix, name, value) {
+  return {
+    type: typeOf(name, value),
+    name: nameOf(name, prefix),
+    value: valueOf(name, value),
+  };
+}
+
+
+// Values: EPAgent only support integers
+function valueOf(name, value, path) {
+  return value|0;
+}
+
+
+// Names: | separated path with : separator before value name
+
+var TIERS_RX = /^(tiers)\.(.+)_(in|out).(average)$/;
+
+function translateName(name, prefix) {
+  if (TIERS_RX.test(name)) {
+    name = tiersName(name);
+  } else {
+    name = simpleName(name);
+  }
+  return prefix + '|' + name;
+}
+
+function simpleName(name) {
+  var parts = name.split('.').map(sanitizePart);
+  name = [parts.slice(0, -1).join('|'), parts.slice(-1)].join(':');
+  return name;
+}
+
+function tiersName(name) {
+  var parts = TIERS_RX.exec(name).map(sanitizePart);
+  var head = [ 'backends', parts[1], parts[2], parts[3] ].join('|');
+  return [ head, parts[4] ].join(':');
+}
+
+function sanitizePart(str) {
+  return str.replace(/[:|]/g, '-');
+}
+
+
+// Types: IntCounter, IntAverage, ...
+
+var COUNT_RX = /\.count$/;
+var TIMER_RX = /\.timer$/;
+var AVG_RX = /\.(average|min|max)$/;
+
+function translateType(name) {
+  if (COUNT_RX.test(name)) {
+    return 'IntCounter';
+  } else if (AVG_RX.test(name)) {
+    return 'IntAverage';
+  } else if (TIERS_RX.test(name)) {
+    return 'IntAverage';
+  } else {
+    return 'IntCounter';
+  }
+}

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,0 +1,78 @@
+var debug = require('debug')('strong-agent-ca:reporter');
+var http = require('http');
+var os = require('os');
+
+var makeMetric = require('./metric');
+var concat = require('concat-stream');
+
+module.exports = exports = Reporter;
+
+function Reporter(opts) {
+  if (!(this instanceof Reporter)) {
+    return new Reporter(opts);
+  }
+  debug('Reporter(%j)', opts);
+
+  opts = opts || {};
+  this.host = opts.host || 'localhost';
+  this.port = opts.port || 8080;
+  this.metricsPath = opts.metricsPath || ('nodejsStats|' + os.hostname().split('.', 1)[0]);
+
+  // provide a string matching how strong-agent filters collector requests
+  if (this.port == 80)
+    this.hostString = this.host;
+  else
+    this.hostString = this.host + ':' + this.port;
+}
+
+Reporter.prototype.prepare = prepare;
+Reporter.prototype.report = report;
+Reporter.prototype.reqOpts = reqOpts;
+
+function prepare(raw) {
+  debug('prepare(%j)', raw);
+  var metrics = {
+    metrics: [],
+    // These must either not be set, or set to the exact values that
+    // EPAgent is expecting.. I'm not sure what their actual purpose is.
+    // host: os.hostname().split('.', 1)[0],
+    // process: 'node-demo',
+    // agent: 'NodeAgent',
+  };
+  for (var m in raw) {
+    metrics.metrics.push(makeMetric(this.metricsPath, m, raw[m]));
+  }
+  process.nextTick(this.report.bind(this, metrics));
+}
+
+function report(metrics) {
+  debug('report', metrics);
+  var req = http.request(this.reqOpts());
+  req.on('response', function(res) {
+    res.pipe(concat(function(body) {
+      try {
+        body = JSON.parse(body);
+      } catch (e) {}
+      debug('EPAgent Response:', body);
+    }));
+  });
+  req.on('error', function(err) {
+    // TODO: proper error handling/logging
+    debug('EPAgent Error:', err);
+  });
+  req.end(JSON.stringify(metrics));
+  debug('Sent to EPAgent:', metrics);
+}
+
+function reqOpts() {
+  return {
+    hostname: this.host,
+    port: this.port,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+    path: '/apm/metricFeed',
+    agent: false, // avoid instrumentation and app side effects
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "strong-agent-ca",
+  "version": "1.0.0-0",
+  "description": "strong-agent plugin that reports to CA EPAgent REST API",
+  "main": "index.js",
+  "scripts": {
+    "test": "tap test/test-*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:strongloop/strong-agent-ca.git"
+  },
+  "author": "StrongLoop <callback@strongloop.com>",
+  "license": "None",
+  "bugs": {
+    "url": "https://github.com/strongloop/strong-agent-ca/issues"
+  },
+  "homepage": "https://github.com/strongloop/strong-agent-ca",
+  "devDependencies": {
+    "tap": "^0.4.13"
+  },
+  "dependencies": {
+    "concat-stream": "^1.4.6",
+    "debug": "^2.1.0",
+    "lodash": "^2.4.1"
+  }
+}

--- a/test/test-collect.js
+++ b/test/test-collect.js
@@ -1,0 +1,21 @@
+var tap = require('tap');
+var Collector = require('../lib/collector');
+
+tap.test('Collector.collect', function(t) {
+  var collector = new Collector({interval: 500});
+
+  collector.once('metrics', verifyMetrics);
+  collector.collect('h.p.a.counter', 1);
+  collector.collect('h.p.b.average', 2);
+  collector.collect('h.p.c.gauge', 3);
+
+  function verifyMetrics(metrics) {
+    t.deepEqual(metrics, {
+      'h.p.a.counter': 1,
+      'h.p.b.average': 2,
+      'h.p.c.gauge': 3,
+    }, 'collector aggregates metrics');
+    collector.stop();
+    t.end();
+  }
+});

--- a/test/test-namer.js
+++ b/test/test-namer.js
@@ -1,0 +1,15 @@
+var test = require('tap').test;
+var getName = require('../lib/metric').getName;
+
+test('metric.getName', function(t) {
+  t.equal(getName('tiers.54.191.244.236_out.average', 'PREFIX'),
+          'PREFIX|backends|tiers|54.191.244.236|out:average',
+          'treats outbound http requests as backend');
+  t.equal(getName('tiers.54.191.244.236_in.average', 'PREFIX'),
+          'PREFIX|backends|tiers|54.191.244.236|in:average',
+          'treats outbound http responses as backend');
+  t.equal(getName('tiers.54.191.244.236:8080_in.average', 'PREFIX'),
+          'PREFIX|backends|tiers|54.191.244.236-8080|in:average',
+          'translates separators to -');
+  t.end();
+});

--- a/test/test-report.js
+++ b/test/test-report.js
@@ -1,0 +1,36 @@
+var tap = require('tap');
+var http = require('http');
+var Reporter = require('../lib/reporter');
+var concat = require('concat-stream')
+
+tap.test('reporter.collect', function(t) {
+  var metricsPath = 'testStats';
+  var collected = {
+    'h.p.a.counter': 1,
+    'h.p.b.average': 2,
+    'h.p.c.gauge': 3,
+  };
+  var expectedReport = {
+    metrics: [
+      { type: 'IntCounter', name: 'testStats|h|p|a:counter', value: 1 },
+      { type: 'IntAverage', name: 'testStats|h|p|b:average', value: 2 },
+      { type: 'IntCounter', name: 'testStats|h|p|c:gauge', value: 3 },
+    ],
+  };
+
+  var epAgent = http.createServer(function(req, res) {
+    req.pipe(concat(function(body) {
+      t.equal(req.url, '/apm/metricFeed');
+      t.deepEqual(JSON.parse(body), expectedReport);
+      res.end();
+      epAgent.close(t.end.bind(t));
+    }));
+  });
+
+  epAgent.listen(0, function() {
+    Reporter({
+      port: epAgent.address().port,
+      metricsPath: metricsPath
+    }).prepare(collected);
+  });
+});

--- a/test/test-typer.js
+++ b/test/test-typer.js
@@ -1,0 +1,12 @@
+var test = require('tap').test;
+var getType = require('../lib/metric').getType;
+
+test('metric.getType', function(t) {
+  t.equal(getType('tiers.54.191.244.236_out.average'), 'IntAverage',
+          'tiers averages are IntAverages');
+  t.equal(getType('loop.max'), 'IntAverage',
+          'max values are IntAverage');
+  t.equal(getType('loop.count'), 'IntCounter',
+          'loop.count is IntCounter');
+  t.end();
+});


### PR DESCRIPTION
- [x] Accept metrics of form `[ [k1, v1], [k2, v2]... ]`
- [x] Forward data to REST API at given host/port
- [x] Prefix metrics with given metrics path
- [x] tests for collect -> POST

When the details are available:
- [ ] Support multiple types
- [ ] Write validating test agent
- [ ] Handle response codes

For strongloop-internal/scrum-nodeops#174

/cc @chandadharap 
